### PR TITLE
Fix Git installation step in workflow

### DIFF
--- a/.github/workflows/update_events.yml
+++ b/.github/workflows/update_events.yml
@@ -14,6 +14,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Install dependencies
         run: pip install --no-cache-dir -r requirements.txt
+      - name: Install Git
+        run: apt-get update && apt-get install -y git
       - name: Run script
         run: python .scripts/events_updater.py
       - name: Set up Git


### PR DESCRIPTION
The current workflow is missing the installation of Git, which is necessary for the script to run successfully. This pull request fixes the issue by adding a step to install Git before running the script.

Fixes #1234