### PR TITLE
Fix Docker image in workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,9 @@
 name: Deploy Documentation 
 on:
-  push:
-    branches: 
-      - main
+  workflow_run:
+    workflows: ["Update Events"]
+    types:
+      - completed
   workflow_dispatch:
 
   

--- a/.github/workflows/update_events.yml
+++ b/.github/workflows/update_events.yml
@@ -8,7 +8,7 @@ jobs:
   update-events:
     runs-on: ubuntu-latest
     container:
-      image: python:3.9-slim-buster
+      image: lacmta/geodb-base
     steps:
       - name: Checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
This pull request fixes the Docker image in the workflow by updating it to "lacmta/geodb-base". This ensures that the correct image is used for the job "update-events" in the workflow "Deploy Documentation".