### PR TITLE
Update event schedule and add push trigger

### DIFF
--- a/.github/workflows/update_events.yml
+++ b/.github/workflows/update_events.yml
@@ -1,8 +1,11 @@
 name: Update Events
 on:
-    schedule:
-        - cron: '0 0 * * *'  # Runs every day at 00:00 UTC
-    workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'  # Runs every day at 00:00 UTC
+  push:
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
   update-events:


### PR DESCRIPTION
This pull request updates the event schedule to run every day at 00:00 UTC and adds a push trigger for the main branch. This ensures that the events are updated daily and triggers the workflow when changes are pushed to the main branch.