### PR TITLE
Remove unnecessary git installation line

### DIFF
--- a/.github/workflows/update_events.yml
+++ b/.github/workflows/update_events.yml
@@ -17,8 +17,6 @@ jobs:
         uses: actions/checkout@v2
       - name: Install dependencies
         run: pip install --no-cache-dir -r requirements.txt
-      - name: Install Git
-        run: apt-get update && apt-get install -y git
       - name: Run script
         run: python .scripts/events_updater.py
       - name: Set up Git


### PR DESCRIPTION
This pull request removes the unnecessary line that installs Git in the workflow file. The line was mistakenly included and is not required for the execution of the script. This change simplifies the workflow and makes sure the pipeline can run.