### PR TITLE
feat: add link to title and remove link column on the presentation page

### DIFF
--- a/generate-presentations-index.js
+++ b/generate-presentations-index.js
@@ -15,16 +15,16 @@ fs.createReadStream('presentations.csv')
         let markdownEN = '# Presentations\n\n';
         let markdownJP = '# プレゼンテーション\n\n'; // Translated "Presentations"
 
-        markdownEN += '| Title | Date |Speaker | Link | Keywords |\n';
-        markdownEN += '| ----- | ---- | ------- | ---- | -------- |\n';
+        markdownEN += '| Title | Date | Speaker | Keywords |\n';
+        markdownEN += '| ----- | ---- | ------- | -------- |\n';
 
-        markdownJP += '| タイトル | 日付 | スピーカー | リンク | キーワード |\n'; // Translated headers
-        markdownJP += '| ------ | ---- | -------- | ---- | -------- |\n';
+        markdownJP += '| タイトル | 日付 | スピーカー | キーワード |\n'; // Translated headers
+        markdownJP += '| ------ | ---- | -------- | -------- |\n';
 
         presentations.forEach((presentation) => {
-            markdownEN += `| ${presentation["presentation title"]} | ${presentation.date} | ${presentation.speaker} | [Link](${presentation.link}) | ${presentation.keywords} |\n`;
-
-            markdownJP += `| ${presentation["presentation title"]} | ${presentation.date} | ${presentation.speaker} | [リンク](${presentation.link}) | ${presentation.keywords} |\n`; // Translated "Link"
+            let presentationRow = `| [${presentation['presentation title']}](${presentation.link}) | ${presentation.date} | ${presentation.speaker} | ${presentation.keywords} |\n`;
+            markdownEN += presentationRow;
+            markdownJP += presentationRow;
         });
 
         fs.writeFileSync('docs/resources/presentations/index.md', markdownEN);

--- a/presentations.csv
+++ b/presentations.csv
@@ -1,3 +1,6 @@
 "presentation title",date,time,speaker,link,keywords
-"UN Smart Maps Quarterly #1",2023-08-09,16:45,"Hidenori Fujimura and Yuiseki Matsumura ","https://docs.google.com/presentation/d/1OwuZeywXDsbAmpsuYT3m70hp4psQag7O8nfHJZNzvrs/edit?usp=sharing","UN, Smartmaps, quarterly"
+"UN Smart Maps Quarterly #1",2023-08-09,16:45,"Hidenori Fujimura and Yuiseki","https://docs.google.com/presentation/d/1OwuZeywXDsbAmpsuYT3m70hp4psQag7O8nfHJZNzvrs/edit?usp=sharing","UN, Smartmaps, quarterly"
 "Documentation Update",2023-08-20,03:00,"Albert Kochaphum","https://hackmd.io/@MXxudfFtSvSvSonMo4L3qQ/SyT0kFwqn#/1","documentation, UN Smartmaps"
+"Smart Maps report",2024-02-14,23:00+09:00,"Hidenori Fujimura","https://hackmd.io/@smartmaps/2024-02#/","UN Open GIS Monthly"
+"Smart Maps and Bazaar",2024-02-20,10:00+09:00,"Hidenori Fujimura","https://speakerdeck.com/hfu/smart-maps-and-bazaar","Tech for Peace Symposium 2024"
+"実践のコミュニティとしてのUN Smart Maps Group",2024-02-20,11:00+09:00,"Yuiseki","https://speakerdeck.com/yuiseki/shi-jian-nokomiyuniteitositeno-un-smart-maps-group","Tech for Peace Symposium 2024"


### PR DESCRIPTION
## Issue
https://github.com/UNopenGIS/7/issues/398
We said the link should be in the title on the presentation page.
![image](https://github.com/UNopenGIS/smartmaps/assets/83101503/d07069fc-c635-4648-862c-e2003e9219ab)

## Description
I add link to title and remove link column on the presentation page.

![image](https://github.com/UNopenGIS/smartmaps/assets/83101503/abca966e-6220-43cd-8801-d7eb12f1a969)
I changed script. How about this commit?