### PR TITLE
Remove the link to "Upcoming Events" (tentatively). 

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -37,13 +37,6 @@ function HomepageHeader() {
                 Join UN Smart Maps
               </Translate>
            </Link>
-          <Link
-            className="button button--secondary button--lg"
-            to="/events">
-              <Translate>
-                See upcoming events
-              </Translate>
-           </Link>
         </div>
       </div>
     </header>


### PR DESCRIPTION
(Tentatively) remove the link to "Upcoming Events" because the event list is not currently updated.